### PR TITLE
fix: ノートのソートにおいて、created_atとupdated_atが効かない #50

### DIFF
--- a/app/controllers/v1/notes_controller.rb
+++ b/app/controllers/v1/notes_controller.rb
@@ -129,7 +129,7 @@ class V1::NotesController < V1::ApplicationController
     # 並び順が指定なし、あるは誤っている場合は、デフォルトとして昇順を設定する
     sort_order = 'asc' if !sort_order || (sort_order != 'asc' && sort_order != 'desc')
 
-    if Task.column_names.include?(sort_column)
+    if sort_column == 'date_to'
       sort_column = "tasks.#{sort_column}"
       # タスクが紐づく、かつ、タスクが未完了、かつソート対象のカラムがNULLではないものから、並び替えを実行する
       return Arel.sql(


### PR DESCRIPTION
task.date_toでのソート機能追加によるデグレ。
リクエストパラメータで指定されたソート対象のカラムが、タスクテーブルに存在するカラムの場合に特殊な処理を実装していたが、created_atとupdated_atはタスクテーブルにも存在するため、タスク固有処理に分岐され、想定外の挙動になっていた。